### PR TITLE
Update Qt5 to 5.10.1 and enable Qt5 build.

### DIFF
--- a/scripts/macosx/build_environment.sh
+++ b/scripts/macosx/build_environment.sh
@@ -119,8 +119,7 @@ $PROGDIR/build_rubberband.sh
 $PROGDIR/build_sqlite.sh
 $PROGDIR/build_openssl.sh
 $PROGDIR/build_qt4.sh # depends on sqlite, openssl
-# Re-enable once we support Qt5.
-#$PROGDIR/build_qt5.sh # depends on sqlite, openssl
+$PROGDIR/build_qt5.sh # depends on sqlite
 $PROGDIR/build_sndfile.sh
 $PROGDIR/build_taglib.sh
 $PROGDIR/build_vorbis.sh

--- a/scripts/macosx/build_qt4.sh
+++ b/scripts/macosx/build_qt4.sh
@@ -27,6 +27,7 @@ export ARCH_FLAGS=
 export DISABLE_FFAST_MATH=yes
 
 source $PROGDIR/environment.sh
+export QTDIR=$MIXXX_PREFIX/Qt-${VERSION_NUMBER}
 
 # Qt uses -arch x86 not -arch i386. -arch ppc is no longer supported.
 QT_ARCHS=()
@@ -69,7 +70,7 @@ curl https://raw.githubusercontent.com/Homebrew/patches/480b7142c4e2ae07de6028f6
 # - http://www.mimec.org/node/296
 # NOTE(rryan): Setting -system-sqlite sets -system-zlib. Set -qt-zlib explicitly.
 export OPENSSL_LIBS="-L${MIXXX_PREFIX}/lib -lssl -lcrypto"
-./configure -opensource -prefix ${MIXXX_PREFIX} ${QT_ARCHS[@]} -sdk $OSX_SDK -system-sqlite -qt-sql-sqlite -qt-zlib -no-phonon -no-webkit -no-qt3support -release -nomake examples -nomake demos -confirm-license -openssl -I${MIXXX_PREFIX}/include -L${MIXXX_PREFIX}/lib
+./configure -opensource -prefix ${QTDIR} ${QT_ARCHS[@]} -sdk $OSX_SDK -system-sqlite -qt-sql-sqlite -qt-zlib -no-phonon -no-webkit -no-qt3support -release -nomake examples -nomake demos -confirm-license -openssl -I${MIXXX_PREFIX}/include -L${MIXXX_PREFIX}/lib
 
 make && make install
 

--- a/scripts/macosx/build_qt5.sh
+++ b/scripts/macosx/build_qt5.sh
@@ -11,9 +11,9 @@ pushd `dirname $0` > /dev/null
 PROGDIR=`pwd -P`
 popd > /dev/null
 
-export VERSION_NUMBER=5.6.0
-export VERSION=qt-everywhere-opensource-src-${VERSION_NUMBER}
-export ARCHIVE=$VERSION.tar.gz
+export VERSION_NUMBER=5.10.1
+export VERSION=qt-everywhere-src-${VERSION_NUMBER}
+export ARCHIVE=$VERSION.tar.xz
 
 echo "Building $VERSION for $MIXXX_ENVIRONMENT_NAME for architectures: ${MIXXX_ARCHS[@]}"
 
@@ -29,30 +29,16 @@ export DISABLE_FFAST_MATH=yes
 source $PROGDIR/environment.sh
 export QTDIR=$MIXXX_PREFIX/Qt-${VERSION_NUMBER}
 
-# Qt uses -arch x86 not -arch i386. -arch ppc is no longer supported.
-QT_ARCHS=()
-for ARCH in ${MIXXX_ARCHS[@]}
-do
-  if [[ "$ARCH" == "i386" ]]; then
-      QT_ARCHS+=(-arch x86)
-  elif [[ "$ARCH" == "x86_64" ]]; then
-      QT_ARCHS+=(-arch x86_64)
-  elif [[ "$ARCH" == "ppc" ]]; then
-      echo "ppc is unsupported by Qt!"
-      exit 1
-  fi
-done
-
 echo "Building $VERSION for $MIXXX_ENVIRONMENT_NAME for architectures: ${QT_ARCHS[@]}"
 
 # Mixxx may want to call sqlite functions directly so we use the statically
-# linked version of SQLite (-qt-sql-sqlite) and link it to the system SQLite
+# linked version of SQLite (-sql-sqlite) and link it to the system SQLite
 # (-system-sqlite) instead of the SQLite plugin
 # (-plugin-sql-sqlite).
 # See:
 # - http://www.mimec.org/node/296
 # NOTE(rryan): Setting -system-sqlite sets -system-zlib. Set -qt-zlib explicitly.
-./configure -opensource -prefix $QTDIR ${QT_ARCHS[@]} -sdk macosx${MIXXX_MACOSX_SDK} -system-sqlite -qt-sql-sqlite -qt-zlib -platform macx-g++ -release -confirm-license -force-debug-info -nomake examples -nomake tests -skip qt3d -skip qtwebengine
+./configure -opensource -prefix $QTDIR -sdk macosx${MIXXX_MACOSX_SDK} -system-sqlite -sql-sqlite -qt-zlib -platform macx-clang -release -confirm-license -securetransport -force-debug-info -nomake examples -nomake tests -skip qt3d -skip qtwebengine -I${MIXXX_PREFIX}/include -L${MIXXX_PREFIX}/lib
 
 make && make install
 cd ..

--- a/scripts/macosx/download_dependencies.sh
+++ b/scripts/macosx/download_dependencies.sh
@@ -51,7 +51,7 @@ download_and_verify http://www.portaudio.com/archives/pa_stable_v190600_20161030
 download_and_verify http://downloads.sourceforge.net/project/portmedia/portmidi/217/portmidi-src-217.zip 08e9a892bd80bdb1115213fb72dc29a7bf2ff108b378180586aa65f3cfd42e0f
 download_and_verify https://github.com/google/protobuf/archive/v2.6.1.tar.gz 2667b7cda4a6bc8a09e5463adf3b5984e08d94e72338277affa8594d8b6e5cd1 protobuf-2.6.1.tar.gz
 download_and_verify https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0
-download_and_verify https://download.qt.io/archive/qt/5.6/5.6.0/single/qt-everywhere-opensource-src-5.6.0.tar.gz 7716bf4b231ab1768676a49e19781b5e03b27b9068d6685857e5ec43e9f836bf
+download_and_verify https://download.qt.io/archive/qt/5.10/5.10.1/single/qt-everywhere-src-5.10.1.tar.xz 05ffba7b811b854ed558abf2be2ddbd3bb6ddd0b60ea4b5da75d277ac15e740a
 download_and_verify http://code.breakfastquay.com/attachments/download/34/rubberband-1.8.1.tar.bz2 ff0c63b0b5ce41f937a8a3bc560f27918c5fe0b90c6bc1cb70829b86ada82b75
 download_and_verify http://downloads.xiph.org/releases/libshout/libshout-2.4.1.tar.gz f3acb8dec26f2dbf6df778888e0e429a4ce9378a9d461b02a7ccbf2991bbf24d
 download_and_verify http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.26.tar.gz cd6520ec763d1a45573885ecb1f8e4e42505ac12180268482a44b28484a25092


### PR DESCRIPTION
* Disable openssl in Qt5 in favor of securetransport.
* Build sqlite as a static library only, since the Qt5 build fails if a dylib is present.