### PR TITLE
Go back to Qt 5.10.1 to fix build issues on Mac Os

### DIFF
--- a/scripts/macosx/build_qt5.sh
+++ b/scripts/macosx/build_qt5.sh
@@ -11,7 +11,7 @@ pushd `dirname $0` > /dev/null
 PROGDIR=`pwd -P`
 popd > /dev/null
 
-export VERSION_NUMBER=5.11.1
+export VERSION_NUMBER=5.10.1
 export VERSION=qt-everywhere-src-${VERSION_NUMBER}
 export ARCHIVE=$VERSION.tar.xz
 

--- a/scripts/macosx/download_dependencies.sh
+++ b/scripts/macosx/download_dependencies.sh
@@ -51,7 +51,8 @@ download_and_verify http://www.portaudio.com/archives/pa_stable_v190600_20161030
 download_and_verify http://downloads.sourceforge.net/project/portmedia/portmidi/217/portmidi-src-217.zip 08e9a892bd80bdb1115213fb72dc29a7bf2ff108b378180586aa65f3cfd42e0f
 download_and_verify https://github.com/google/protobuf/archive/v2.6.1.tar.gz 2667b7cda4a6bc8a09e5463adf3b5984e08d94e72338277affa8594d8b6e5cd1 protobuf-2.6.1.tar.gz
 #download_and_verify https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0
-download_and_verify https://download.qt.io/archive/qt/5.11/5.11.1/single/qt-everywhere-src-5.11.1.tar.xz 39602cb08f9c96867910c375d783eed00fc4a244bffaa93b801225d17950fb2b
+download_and_verify https://download.qt.io/archive/qt/5.10/5.10.1/single/qt-everywhere-src-5.10.1.tar.xz 05ffba7b811b854ed558abf2be2ddbd3bb6ddd0b60ea4b5da75d277ac15e740a
+#download_and_verify https://download.qt.io/archive/qt/5.11/5.11.1/single/qt-everywhere-src-5.11.1.tar.xz 39602cb08f9c96867910c375d783eed00fc4a244bffaa93b801225d17950fb2b
 download_and_verify http://code.breakfastquay.com/attachments/download/34/rubberband-1.8.1.tar.bz2 ff0c63b0b5ce41f937a8a3bc560f27918c5fe0b90c6bc1cb70829b86ada82b75
 download_and_verify http://downloads.xiph.org/releases/libshout/libshout-2.4.1.tar.gz f3acb8dec26f2dbf6df778888e0e429a4ce9378a9d461b02a7ccbf2991bbf24d
 download_and_verify http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.26.tar.gz cd6520ec763d1a45573885ecb1f8e4e42505ac12180268482a44b28484a25092


### PR DESCRIPTION
I think it does not make a big difference for Mac OS. This way we can officially announce a 2.2 beta assuming that this succeeds and postpone the OSX Qt update to Mixxx 2.3 or later. 