### PR TITLE
[2.2.x] libopus(windows): copy static celt and silk dependencies

### DIFF
--- a/build_libopus.bat
+++ b/build_libopus.bat
@@ -25,6 +25,15 @@ IF ERRORLEVEL 1 (
 
 copy %PLATFORM%\%CONFIG%\opus.lib %LIB_DIR%
 copy %PLATFORM%\%CONFIG%\opus.pdb %LIB_DIR%
+copy %PLATFORM%\%CONFIG%\celt.lib %LIB_DIR%
+copy %PLATFORM%\%CONFIG%\celt.pdb %LIB_DIR%
+copy %PLATFORM%\%CONFIG%\silk_common.lib %LIB_DIR%
+copy %PLATFORM%\%CONFIG%\silk_common.pdb %LIB_DIR%
+copy %PLATFORM%\%CONFIG%\silk_float.lib %LIB_DIR%
+copy %PLATFORM%\%CONFIG%\silk_float.pdb %LIB_DIR%
+copy %PLATFORM%\%CONFIG%\silk_fixed.lib %LIB_DIR%
+copy %PLATFORM%\%CONFIG%\silk_fixed.pdb %LIB_DIR%
+
 if NOT %STATIC_LIBS% ( copy %PLATFORM%\%CONFIG%\opus.dll %LIB_DIR% )
 md %INCLUDE_DIR%\opus
 copy ..\..\include\*.h %INCLUDE_DIR%\opus\


### PR DESCRIPTION
This PR should fix the Opus encoder dependency issues encountered on Windows in https://github.com/mixxxdj/mixxx/pull/1386.