### PR TITLE
update Qt to 5.12.3 on macOS

### DIFF
--- a/scripts/macosx/build_environment.sh
+++ b/scripts/macosx/build_environment.sh
@@ -16,7 +16,7 @@ MIXXX_MACOSX_SDK=$(xcodebuild -version -sdk macosx SDKVersion)
 # Qt 5.11 requires a minimum of macOS 10.11.
 MIXXX_MACOSX_TARGET='10.11'
 MIXXX_MACOSX_STDLIB='libc++'
-MIXXX_QT_VERSION='5.12.0'
+MIXXX_QT_VERSION='5.12.3'
 ENABLE_I386=false
 ENABLE_X86_64=false
 ENABLE_PPC=false

--- a/scripts/macosx/download_dependencies.sh
+++ b/scripts/macosx/download_dependencies.sh
@@ -51,7 +51,7 @@ download_and_verify http://www.portaudio.com/archives/pa_stable_v190600_20161030
 download_and_verify http://downloads.sourceforge.net/project/portmedia/portmidi/217/portmidi-src-217.zip 08e9a892bd80bdb1115213fb72dc29a7bf2ff108b378180586aa65f3cfd42e0f
 download_and_verify https://github.com/google/protobuf/archive/v2.6.1.tar.gz 2667b7cda4a6bc8a09e5463adf3b5984e08d94e72338277affa8594d8b6e5cd1 protobuf-2.6.1.tar.gz
 #download_and_verify https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0
-download_and_verify https://download.qt.io/archive/qt/5.12/5.12.0/single/qt-everywhere-src-5.12.0.tar.xz 356f42d9087718f22f03d13d0c2cdfb308f91dc3cf0c6318bed33f2094cd9d6c
+download_and_verify https://download.qt.io/archive/qt/5.12/5.12.3/single/qt-everywhere-src-5.12.3.tar.xz 6462ac74c00ff466487d8ef8d0922971aa5b1d5b33c0753308ec9d57711f5a42
 download_and_verify http://code.breakfastquay.com/attachments/download/34/rubberband-1.8.1.tar.bz2 ff0c63b0b5ce41f937a8a3bc560f27918c5fe0b90c6bc1cb70829b86ada82b75
 download_and_verify http://downloads.xiph.org/releases/libshout/libshout-2.4.1.tar.gz f3acb8dec26f2dbf6df778888e0e429a4ce9378a9d461b02a7ccbf2991bbf24d
 download_and_verify http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.26.tar.gz cd6520ec763d1a45573885ecb1f8e4e42505ac12180268482a44b28484a25092


### PR DESCRIPTION
Qt 5.12.3 brings major performance improvements to macOS:
https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/2.2E3.20planning/near/164910803
https://code.qt.io/cgit/qt/qtbase.git/log/?qt=range&q=77a4915bf900aac0c96260018c0a4ccfbdd7c094&showmsg=1