### PR TITLE
[2.3.x unix] Add libshout-idjc

### DIFF
--- a/scripts/macosx/build_environment.sh
+++ b/scripts/macosx/build_environment.sh
@@ -125,8 +125,9 @@ $PROGDIR/build_openssl.sh
 $PROGDIR/build_sndfile.sh
 $PROGDIR/build_taglib.sh
 $PROGDIR/build_vorbis.sh
-# Shout depends on openssl, libogg and libvorbis.
+# Shout & its IDJC variant depend on openssl, libogg and libvorbis.
 $PROGDIR/build_shout.sh
+$PROGDIR/build_shoutidjc.sh
 $PROGDIR/build_lame.sh
 $PROGDIR/build_lv2.sh
 $PROGDIR/build_serd.sh

--- a/scripts/macosx/build_shout.sh
+++ b/scripts/macosx/build_shout.sh
@@ -11,15 +11,15 @@ pushd `dirname $0` > /dev/null
 PROGDIR=`pwd -P`
 popd > /dev/null
 
-export VERSION_NUMBER=idjc-2.4.1
-export VERSION=libshout-${VERSION_NUMBER}
+export VERSION_NUMBER=2.4.1
+export VERSION=libshout-idjc-${VERSION_NUMBER}
 export ARCHIVE=$VERSION.tar.gz
 
 echo "Building $VERSION for $MIXXX_ENVIRONMENT_NAME for architectures: ${MIXXX_ARCHS[@]}"
 
 # You may need to change these from version to version.
-export DYLIB=src/.libs/libshout.3.dylib
-export STATICLIB=src/.libs/libshout.a
+export DYLIB=src/.libs/libshout-idjc.3.dylib
+export STATICLIB=src/.libs/libshout-idjc.a
 
 for ARCH in ${MIXXX_ARCHS[@]}
 do

--- a/scripts/macosx/build_shout.sh
+++ b/scripts/macosx/build_shout.sh
@@ -11,7 +11,7 @@ pushd `dirname $0` > /dev/null
 PROGDIR=`pwd -P`
 popd > /dev/null
 
-export VERSION_NUMBER=2.4.1
+export VERSION_NUMBER=idjc-2.4.1
 export VERSION=libshout-${VERSION_NUMBER}
 export ARCHIVE=$VERSION.tar.gz
 

--- a/scripts/macosx/build_shoutidjc.sh
+++ b/scripts/macosx/build_shoutidjc.sh
@@ -12,14 +12,14 @@ PROGDIR=`pwd -P`
 popd > /dev/null
 
 export VERSION_NUMBER=2.4.1
-export VERSION=libshout-${VERSION_NUMBER}
+export VERSION=libshout-idjc-${VERSION_NUMBER}
 export ARCHIVE=$VERSION.tar.gz
 
 echo "Building $VERSION for $MIXXX_ENVIRONMENT_NAME for architectures: ${MIXXX_ARCHS[@]}"
 
 # You may need to change these from version to version.
-export DYLIB=src/.libs/libshout.3.dylib
-export STATICLIB=src/.libs/libshout.a
+export DYLIB=src/.libs/libshout-idjc.3.dylib
+export STATICLIB=src/.libs/libshout-idjc.a
 
 for ARCH in ${MIXXX_ARCHS[@]}
 do

--- a/scripts/macosx/build_shoutidjc.sh
+++ b/scripts/macosx/build_shoutidjc.sh
@@ -27,11 +27,6 @@ do
   tar -zxf $DEPENDENCIES/$ARCHIVE -C $VERSION-$ARCH --strip-components 1
   cd $VERSION-$ARCH
 
-  # Apply patch fixing: 
-  # https://trac.xiph.org/ticket/2244
-  # https://bugs.launchpad.net/mixxx/+bug/1544739
-  patch -p1 < $PROGDIR/fix_libshout_ticket2244.patch
-
   source $PROGDIR/environment.sh $ARCH
   ./configure --host $HOST --target $TARGET --disable-dependency-tracking --prefix=$MIXXX_PREFIX
   make

--- a/scripts/macosx/download_dependencies.sh
+++ b/scripts/macosx/download_dependencies.sh
@@ -53,6 +53,7 @@ download_and_verify https://github.com/google/protobuf/archive/v2.6.1.tar.gz 266
 #download_and_verify https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0
 download_and_verify https://download.qt.io/archive/qt/5.12/5.12.3/single/qt-everywhere-src-5.12.3.tar.xz 6462ac74c00ff466487d8ef8d0922971aa5b1d5b33c0753308ec9d57711f5a42
 download_and_verify http://code.breakfastquay.com/attachments/download/34/rubberband-1.8.1.tar.bz2 ff0c63b0b5ce41f937a8a3bc560f27918c5fe0b90c6bc1cb70829b86ada82b75
+download_and_verify http://downloads.xiph.org/releases/libshout/libshout-2.4.1.tar.gz f3acb8dec26f2dbf6df778888e0e429a4ce9378a9d461b02a7ccbf2991bbf24d
 download_and_verify https://downloads.sourceforge.net/project/libshoutidjc.idjc.p/libshout-idjc-2.4.1.tar.gz 4751c75fc85fc5d10e5b03753b046bcdee39576278bf30565c751816a87facdf
 download_and_verify http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.26.tar.gz cd6520ec763d1a45573885ecb1f8e4e42505ac12180268482a44b28484a25092
 download_and_verify http://prdownloads.sourceforge.net/scons/scons-2.5.0.tar.gz eb296b47f23c20aec7d87d35cfa386d3508e01d1caa3040ea6f5bbab2292ace9

--- a/scripts/macosx/download_dependencies.sh
+++ b/scripts/macosx/download_dependencies.sh
@@ -53,7 +53,7 @@ download_and_verify https://github.com/google/protobuf/archive/v2.6.1.tar.gz 266
 #download_and_verify https://download.qt.io/official_releases/qt/4.8/4.8.7/qt-everywhere-opensource-src-4.8.7.tar.gz e2882295097e47fe089f8ac741a95fef47e0a73a3f3cdf21b56990638f626ea0
 download_and_verify https://download.qt.io/archive/qt/5.12/5.12.3/single/qt-everywhere-src-5.12.3.tar.xz 6462ac74c00ff466487d8ef8d0922971aa5b1d5b33c0753308ec9d57711f5a42
 download_and_verify http://code.breakfastquay.com/attachments/download/34/rubberband-1.8.1.tar.bz2 ff0c63b0b5ce41f937a8a3bc560f27918c5fe0b90c6bc1cb70829b86ada82b75
-download_and_verify http://downloads.xiph.org/releases/libshout/libshout-2.4.1.tar.gz f3acb8dec26f2dbf6df778888e0e429a4ce9378a9d461b02a7ccbf2991bbf24d
+download_and_verify https://downloads.sourceforge.net/project/libshoutidjc.idjc.p/libshout-idjc-2.4.1.tar.gz 4751c75fc85fc5d10e5b03753b046bcdee39576278bf30565c751816a87facdf
 download_and_verify http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.26.tar.gz cd6520ec763d1a45573885ecb1f8e4e42505ac12180268482a44b28484a25092
 download_and_verify http://prdownloads.sourceforge.net/scons/scons-2.5.0.tar.gz eb296b47f23c20aec7d87d35cfa386d3508e01d1caa3040ea6f5bbab2292ace9
 download_and_verify https://www.sqlite.org/2016/sqlite-autoconf-3130000.tar.gz e2797026b3310c9d08bd472f6d430058c6dd139ff9d4e30289884ccd9744086b


### PR DESCRIPTION
This PR adds the IDJC variant of libshout 2.4.1 (which supports AAC streaming) next to the original libshout. This will be needed by https://github.com/mixxxdj/mixxx/pull/1387.

These changes only address the macOS dependencies. Ubuntu dependencies are handled in the mixxx repository.