### PR TITLE
Disable relocatable Qt with -no-feature-relocatable.

### DIFF
--- a/scripts/macosx/build_qt5.sh
+++ b/scripts/macosx/build_qt5.sh
@@ -36,7 +36,10 @@ export QTDIR=$MIXXX_PREFIX/Qt-${VERSION_NUMBER}
 # See:
 # - http://www.mimec.org/node/296
 # NOTE(rryan): Setting -system-sqlite sets -system-zlib. Set -qt-zlib explicitly.
-./configure -opensource -prefix $QTDIR -sdk macosx${MIXXX_MACOSX_SDK} -system-sqlite -sql-sqlite -qt-zlib -platform macx-clang -release -confirm-license -securetransport -force-debug-info -nomake examples -nomake tests -skip qt3d -skip qtwebengine -I${MIXXX_PREFIX}/include -L${MIXXX_PREFIX}/lib
+# Disable relocatable qt due to https://bugs.launchpad.net/mixxx/+bug/1871238
+# TODO(rryan): Disable framework build or use frameworks properly. Qt assumes
+# that if frameworks are enabled then they are used for deployment.
+./configure -opensource -prefix $QTDIR -sdk macosx${MIXXX_MACOSX_SDK} -system-sqlite -sql-sqlite -qt-zlib -platform macx-clang -release -confirm-license -securetransport -force-debug-info -no-feature-relocatable -nomake examples -nomake tests -skip qt3d -skip qtwebengine -I${MIXXX_PREFIX}/include -L${MIXXX_PREFIX}/lib
 
 make && make install
 cd ..


### PR DESCRIPTION
We build Qt with frameworks enabled. When frameworks are enabled, relocatable Qt
uses the framework bundle to determine what the relocatable path to Qt libraries
is:
https://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/global/qlibraryinfo.cpp?h=5.14.2#n537

We deploy standalone Qt dylibs without frameworks, so this causes a crash on
launch with Qt 5.14:
https://bugs.launchpad.net/mixxx/+bug/1871238

As a short-term fix, disable relocatable Qt. A longer term fix would be to build
with frameworks disabled, or to actually ship frameworks instead of standalone
libraries.

Tested by building environments locally and compiling/bundling Mixxx. The crash on start no longer occurs.