### PR TITLE
Added ebur128 1.2.6

### DIFF
--- a/scripts/macosx/build_ebur128.sh
+++ b/scripts/macosx/build_ebur128.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Echo commands
+set -x
+
+# Quit on errors
+set -e
+
+# Get the path to our scripts folder.
+pushd `dirname $0` > /dev/null
+PROGDIR=`pwd -P`
+popd > /dev/null
+
+export VERSION_NUMBER=1.2.6
+export VERSION=libebur128-${VERSION_NUMBER}
+export ARCHIVE=$VERSION.tar.gz
+
+echo "Building $VERSION for $MIXXX_ENVIRONMENT_NAME for architectures: ${MIXXX_ARCHS[@]}"
+
+# You may need to change these from version to version.
+export DYLIB_NAME=libebur128.${VERSION_NUMBER}.dylib
+export DYLIB=src/$DYLIB_NAME
+export STATICLIB=src/libebur128_p.a
+
+for ARCH in ${MIXXX_ARCHS[@]}
+do
+  mkdir -p $VERSION-$ARCH
+  tar -zxf $DEPENDENCIES/$ARCHIVE -C $VERSION-$ARCH --strip-components 1
+  cd $VERSION-$ARCH
+  source $PROGDIR/environment.sh $ARCH
+  cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$MIXXX_PREFIX" -DCMAKE_OSX_DEPLOYMENT_TARGET="$MIXXX_MACOSX_TARGET" -DCMAKE_OSX_SYSROOT="$SDKROOT" -DCMAKE_VERBOSE_MAKEFILE=TRUE
+  make clean
+  make
+  cd ..
+done
+
+# Install the $HOST_ARCH version in case there are binaries we want to run.
+export ARCH=$HOST_ARCH
+cd $VERSION-$ARCH
+source $PROGDIR/environment.sh $ARCH
+
+OTHER_DYLIBS=()
+OTHER_STATICLIBS=()
+for OTHER_ARCH in ${MIXXX_ARCHS[@]}
+do
+  if [ $OTHER_ARCH != $ARCH ]; then
+    OTHER_DYLIBS+=(../$VERSION-$OTHER_ARCH/$DYLIB)
+    OTHER_STATICLIBS+=(../$VERSION-$OTHER_ARCH/$STATICLIB)
+  fi
+done
+
+lipo -create ./$DYLIB ${OTHER_DYLIBS[@]} -output ./$DYLIB
+#lipo -create ./$STATICLIB ${OTHER_STATICLIBS[@]} -output ./$STATICLIB
+make install
+# NOTE(rryan): Mixxx depends on id (not rpath) being the full path to the
+# dylib. Until we fix this, set the chromaprint dylib id:
+install_name_tool -id $MIXXX_PREFIX/lib/$DYLIB_NAME $MIXXX_PREFIX/lib/$DYLIB_NAME
+cd ..

--- a/scripts/macosx/build_environment.sh
+++ b/scripts/macosx/build_environment.sh
@@ -117,6 +117,7 @@ $PROGDIR/build_fdk_aac.sh
 $PROGDIR/build_fftw.sh
 $PROGDIR/build_libkeyfinder.sh # depends on fftw
 $PROGDIR/build_chromaprint.sh
+$PROGDIR/build_ebur128.sh
 $PROGDIR/build_flac.sh
 $PROGDIR/build_hss1394.sh
 $PROGDIR/build_libusb.sh

--- a/scripts/macosx/download_dependencies.sh
+++ b/scripts/macosx/download_dependencies.sh
@@ -41,6 +41,7 @@ download_and_verify https://pkg-config.freedesktop.org/releases/pkg-config-0.29.
 download_and_verify https://github.com/acoustid/chromaprint/releases/download/v1.5.0/chromaprint-1.5.0.tar.gz 573a5400e635b3823fc2394cfa7a217fbb46e8e50ecebd4a61991451a8af766a
 download_and_verify https://github.com/ccache/ccache/releases/download/v4.0/ccache-4.0.tar.gz ac97af86679028ebc8555c99318352588ff50f515fc3a7f8ed21a8ad367e3d45
 download_and_verify https://cmake.org/files/v3.19/cmake-3.19.2.tar.gz e3e0fd3b23b7fb13e1a856581078e0776ffa2df4e9d3164039c36d3315e0c7f0
+download_and_verify https://github.com/jiixyj/libebur128/archive/refs/tags/v1.2.6.tar.gz baa7fc293a3d4651e244d8022ad03ab797ca3c2ad8442c43199afe8059faa613 libebur128-1.2.6.tar.gz
 download_and_verify http://downloads.xiph.org/releases/flac/flac-1.3.3.tar.xz 213e82bd716c9de6db2f98bcadbc4c24c7e2efe8c75939a1a84e28539c4e1748
 download_and_verify http://fftw.org/fftw-3.3.9.tar.gz bf2c7ce40b04ae811af714deb512510cc2c17b9ab9d6ddcf49fe4487eea7af3d
 download_and_verify https://github.com/mixxxdj/libKeyFinder/archive/v2.2.3.tar.gz 6d8c1306ef9fa31f434ebb81ae2b9df62a001b234edbbf32a727109f8f251c3f libKeyFinder-2.2.3.tar.gz


### PR DESCRIPTION
This is a prerequisite for removing the  lib/libebur128 from the mixxx repo. 
This was discussed here: https://github.com/mixxxdj/mixxx/pull/3908